### PR TITLE
Map Postgres ENUM source type to Arrow LargeUtf8

### DIFF
--- a/connectorx/src/transports/postgres_arrow.rs
+++ b/connectorx/src/transports/postgres_arrow.rs
@@ -52,6 +52,7 @@ macro_rules! impl_postgres_transport {
                 { Int8[i64]                  => Int64[i64]                | conversion auto }
                 { Bool[bool]                 => Boolean[bool]             | conversion auto  }
                 { Text[&'r str]              => LargeUtf8[String]         | conversion owned }
+                { Enum[&'r str]              => LargeUtf8[String]         | conversion none }
                 { BpChar[&'r str]            => LargeUtf8[String]         | conversion none }
                 { VarChar[&'r str]           => LargeUtf8[String]         | conversion none }
                 { Name[&'r str]              => LargeUtf8[String]         | conversion none }

--- a/connectorx/src/transports/postgres_arrowstream.rs
+++ b/connectorx/src/transports/postgres_arrowstream.rs
@@ -49,6 +49,7 @@ macro_rules! impl_postgres_transport {
                 { Int8[i64]                  => Int64[i64]                | conversion auto }
                 { Bool[bool]                 => Boolean[bool]             | conversion auto  }
                 { Text[&'r str]              => LargeUtf8[String]         | conversion owned }
+                { Enum[&'r str]              => LargeUtf8[String]         | conversion none }
                 { BpChar[&'r str]            => LargeUtf8[String]         | conversion none }
                 { VarChar[&'r str]           => LargeUtf8[String]         | conversion none }
                 { Name[&'r str]              => LargeUtf8[String]         | conversion none }


### PR DESCRIPTION
## Summary

Adds a missing `Enum` row to the postgres → arrow / arrowstream transport mapping tables. The Postgres source already recognizes user-defined `ENUM` columns as `PostgresTypeSystem::Enum` (via `tokio_postgres::types::Kind::Enum`) and decodes them as `&str` through the `Type::TEXT` binary path. The arrow and arrowstream transports were missing the variant in their mappings, so any query touching a Postgres `ENUM` column failed at the destination boundary with:

> No conversion rule from Enum(true) to connectorx::destinations::arrow::typesystem::ArrowTypeSystem

## Change

One line per file: `Enum[&'r str] => LargeUtf8[String] | conversion none`.

Uses `conversion none` so the row piggybacks on the `&str → String` `TypeConversion` impl already emitted by the `Text` row. Same trick `BpChar` / `VarChar` / `Name` / `Char` already use — only `Text` carries `conversion owned`, the rest reuse its impl. No new `TypeConversion` impl needed; no existing variants touched.

## Test plan

- [x] `cargo check --features "src_postgres src_bigquery dst_arrow src_trino src_snowflake"` passes (same feature set magnowlia/services uses).
- [ ] After merge, downstream verification in magnowlia: bump `services/Cargo.lock`, rebuild, click "mark as enum" on a Postgres ENUM-typed column and confirm distinct values come back instead of the `NoConversionRule` warning + `DomainSpecific` fallback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)